### PR TITLE
스프링 시큐리티: 폼 인증

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/springsecurity/SampleController.java
+++ b/src/main/java/com/springsecurity/SampleController.java
@@ -1,0 +1,41 @@
+package com.springsecurity;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.security.Principal;
+
+@Controller
+public class SampleController {
+
+    @GetMapping("/")
+    public String index(Model model) {
+        model.addAttribute("message", "Hello Spring Security");
+        return "index";
+    }
+
+    @GetMapping("/info") // 아무나 접근 가능
+    public String info(Model model) {
+        model.addAttribute("message", "Info");
+        return "info";
+    }
+
+    @GetMapping("/dashboard") // 로그인 한 사용자만 접근 가능
+    public String dashboard(Model model, Principal principal) {
+        if (principal == null) {
+            model.addAttribute("message", "Hello Spring Security");
+        } else {
+            model.addAttribute("message", "Hello " + principal.getName());
+        }
+
+        return "dashboard";
+    }
+
+    @GetMapping("/admin") // admin 권한자만 접근 가능
+    public String admin(Model model, Principal principal) {
+        model.addAttribute("message", "Hello Admin, " + principal.getName());
+        return "admin";
+    }
+
+}

--- a/src/main/java/com/springsecurity/SpringSecurityApplication.java
+++ b/src/main/java/com/springsecurity/SpringSecurityApplication.java
@@ -2,9 +2,17 @@ package com.springsecurity;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
 public class SpringSecurityApplication {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(SpringSecurityApplication.class, args);

--- a/src/main/java/com/springsecurity/account/Account.java
+++ b/src/main/java/com/springsecurity/account/Account.java
@@ -1,5 +1,7 @@
 package com.springsecurity.account;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -50,8 +52,8 @@ public class Account {
         this.role = role;
     }
 
-    public void encodePassword() {
-        this.password = "{noop}" + this.password;
+    public void encodePassword(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
     }
 
 }

--- a/src/main/java/com/springsecurity/account/Account.java
+++ b/src/main/java/com/springsecurity/account/Account.java
@@ -1,0 +1,57 @@
+package com.springsecurity.account;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Account {
+
+    @Id @GeneratedValue
+    private Integer id;
+
+    @Column(unique = true)
+    private String username;
+
+    private String password;
+
+    private String role;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+
+    public void encodePassword() {
+        this.password = "{noop}" + this.password;
+    }
+
+}

--- a/src/main/java/com/springsecurity/account/AccountController.java
+++ b/src/main/java/com/springsecurity/account/AccountController.java
@@ -1,0 +1,19 @@
+package com.springsecurity.account;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+
+    @GetMapping("/account/{role}/{username}/{password}") // 임시 회원가입 컨트롤러
+    public Account createAccount(@ModelAttribute Account account) {
+        return accountService.createNew(account);
+    }
+
+}

--- a/src/main/java/com/springsecurity/account/AccountRepository.java
+++ b/src/main/java/com/springsecurity/account/AccountRepository.java
@@ -1,0 +1,7 @@
+package com.springsecurity.account;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Integer> {
+    Account findByUsername(String username);
+}

--- a/src/main/java/com/springsecurity/account/AccountService.java
+++ b/src/main/java/com/springsecurity/account/AccountService.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 public class AccountService implements UserDetailsService { // DB 데이터를 통해 시큐리티 연동
 
     private final AccountRepository accountRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
@@ -28,7 +30,7 @@ public class AccountService implements UserDetailsService { // DB 데이터를 �
     }
 
     public Account createNew(Account account) {
-        account.encodePassword();
+        account.encodePassword(passwordEncoder);
         return accountRepository.save(account);
     }
 

--- a/src/main/java/com/springsecurity/account/AccountService.java
+++ b/src/main/java/com/springsecurity/account/AccountService.java
@@ -1,0 +1,35 @@
+package com.springsecurity.account;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService implements UserDetailsService { // DB 데이터를 통해 시큐리티 연동
+
+    private final AccountRepository accountRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Account account = accountRepository.findByUsername(username);
+        if (account == null) {
+            throw new UsernameNotFoundException(username);
+        }
+
+        return User.builder()
+                .username(account.getUsername())
+                .password(account.getPassword())
+                .roles(account.getRole())
+                .build();
+    }
+
+    public Account createNew(Account account) {
+        account.encodePassword();
+        return accountRepository.save(account);
+    }
+
+}

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.springsecurity.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -19,6 +20,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .formLogin()
                 .and()
                     .httpBasic();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception { // 인메모리 유저 추가
+        auth.inMemoryAuthentication()
+                .withUser("junhan").password("{noop}123").roles("USER")
+                .and()
+                .withUser("admin").password("{noop}!@#").roles("ADMIN");
     }
 
 }

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.springsecurity.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests()
+                .mvcMatchers("/", "/info").permitAll()
+                .mvcMatchers("/admin").hasRole("ADMIN")
+                .anyRequest().authenticated()
+                .and()
+                    .formLogin()
+                .and()
+                    .httpBasic();
+    }
+
+}

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -13,7 +13,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .mvcMatchers("/", "/info").permitAll()
+                .mvcMatchers("/", "/info", "/account/**").permitAll()
                 .mvcMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated()
                 .and()
@@ -22,6 +22,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .httpBasic();
     }
 
+    /*
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception { // 인메모리 유저 추가
         auth.inMemoryAuthentication()
@@ -29,5 +30,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .withUser("admin").password("{noop}!@#").roles("ADMIN");
     }
+     */
 
 }

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -1,4 +1,4 @@
-package com.springsecurity;
+package com.springsecurity.form;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+# \uC218\uB3D9\uC73C\uB85C security user \uC124\uC815 (\uBE44\uCD94\uCC9C)
+#spring.security.user.name=admin
+#spring.security.user.password=123
+#spring.security.user.roles=ADMIN

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@
 #spring.security.user.name=admin
 #spring.security.user.password=123
 #spring.security.user.roles=ADMIN
+
+# h2 database
+spring.h2.console.enabled=true

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Admin</title>
+</head>
+<body>
+<h1 th:text="${message}">Admin</h1>
+</body>
+</html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard</title>
+</head>
+<body>
+<h1 th:text="${message}">Dashboard</h1>
+</body>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Index</title>
+</head>
+<body>
+    <h1 th:text="${message}">Index</h1>
+</body>
+</html>

--- a/src/main/resources/templates/info.html
+++ b/src/main/resources/templates/info.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Info</title>
+</head>
+<body>
+<h1 th:text="${message}">Info</h1>
+</body>
+</html>

--- a/src/test/java/com/springsecurity/account/AccountControllerTest.java
+++ b/src/test/java/com/springsecurity/account/AccountControllerTest.java
@@ -1,0 +1,113 @@
+package com.springsecurity.account;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders.formLogin;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.anonymous;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.unauthenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AccountControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired AccountService accountService;
+
+    @Test
+    public void index_anonymous() throws Exception {
+        mockMvc.perform(get("/").with(anonymous()))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void index_anonymous2() throws Exception { // annonation test
+        mockMvc.perform(get("/"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void index_user() throws Exception { // 로그인 가정
+        mockMvc.perform(get("/").with(user("junhan").roles("USER")))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithUser // 커스터마이징 어노테이션
+//    @WithMockUser(username = "junhan", roles = "USER")
+    public void index_user2() throws Exception {
+        mockMvc.perform(get("/"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void admin_user() throws Exception {
+        mockMvc.perform(get("/admin").with(user("junhan").roles("USER")))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void admin_admin() throws Exception {
+        mockMvc.perform(get("/admin").with(user("junhan").roles("ADMIN")))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(username = "junhan", roles = "ADMIN")
+    public void admin_admin2() throws Exception {
+        mockMvc.perform(get("/admin"))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @Transactional // Test 끝난 뒤 Rollback
+    public void login_success() throws Exception { // 폼 로그인
+        String username = "junhan";
+        String password = "123";
+        Account account = createUser(username, password);
+
+        mockMvc.perform(formLogin().user(account.getUsername()).password(password))
+                .andDo(print())
+                .andExpect(authenticated());
+    }
+
+    @Test
+    @Transactional
+    public void login_fail() throws Exception {
+        String username = "junhan";
+        String password = "123";
+        Account account = createUser(username, password);
+
+        mockMvc.perform(formLogin().user(account.getUsername()).password("12345"))
+                .andDo(print())
+                .andExpect(unauthenticated());
+    }
+
+    private Account createUser(String username, String password) { // 사용자 생성
+        Account account = new Account();
+        account.setUsername(username);
+        account.setPassword(password);
+        account.setRole("USER");
+        return accountService.createNew(account);
+    }
+
+}

--- a/src/test/java/com/springsecurity/account/WithUser.java
+++ b/src/test/java/com/springsecurity/account/WithUser.java
@@ -1,0 +1,11 @@
+package com.springsecurity.account;
+
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@WithMockUser(username = "junhan", roles = "USER")
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithUser {
+}


### PR DESCRIPTION
## 폼 인증 예제

홈 페이지
- /
- 인증된 사용자도 접근할 수 있으며 인증하지 않은 사용자도 접근할 수 있습니다.
- 인증된 사용자가 로그인 한 경우에는 이름을 출력할 것.

정보
- /info
- 이 페이지는 인증을 하지 않고도 접근할 수 있으며, 인증을 한 사용자도 접근할 수 있습니다.

대시보드
- /dashboard
- 이 페이지는 반드시 로그인 한 사용자만 접근할 수 있습니다.
- 인증하지 않은 사용자가 접근할 시 로그인 페이지로 이동합니다.

어드민
- /admin
- 이 페이지는 반드시 ADMIN 권한을 가진 사용자만 접근할 수 있습니다.
- 인증하지 않은 사용자가 접근할 시 로그인 페이지로 이동합니다.
- 인증은 거쳤으나, 권한이 충분하지 않은 경우 에러 메시지를 출력합니다.

## 스프링 웹 프로젝트 만들기

스프링 부트와 타임리프(Thymeleaf)를 사용해서 간단한 웹 애플리케이션 만들기
- https://start.spring.io
- web-start와 thymeleaf 추가
- /, /info, /dashboard, /admin 페이지와 핸들러 만들기

타임리프
- xmlns:th=”http://www.thymeleaf.org” 네임스페이스를 html 태그에 추가.
- th:text=”${message}” 사용해서 Model에 들어있는 값 출력 가능.

현재 문제
- 로그인 할 방법이 없음
- 현재 사용자를 알아낼 방법이 없음

## 스프링 시큐리티 연동

스프링 시큐리티 의존성 추가하기
- 스프링 부트 도움 받아 추가하기
    - 스타터(Starter) 사용
    - 버전 생략 - 스프링 부트의 의존성 관리 기능 사용
```
<dependency>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-starter-security</artifactId>
</dependency>
```

스프링 시큐리티 의존성을 추가하고 나면
- 모든 요청은 인증을 필요로 합니다.
- 기본 유저가 생성됩니다.
    - Username: user
    - Password: 콘솔에 출력된 문자열 확인
```
2019-07-24 11:13:41.245  INFO 10848 --- [           main] .s.s.UserDetailsServiceAutoConfiguration : 

Using generated security password: 114284e0-656a-4fdf-b623-9b552a85b6c8
...
```

해결된 문제
- 인증을 할 수 있다.
- 현재 사용자 정보를 알 수 있다.

새로운 문제
- 인증없이 접근 가능한 URL을 설정하고 싶다.
- 이 애플리케이션을 사용할 수 있는 유저 계정이 그럼 하나 뿐인가?
- 비밀번호가 로그에 남는다고?

## 스프링 시큐리티 설정하기

스프링 웹 시큐리티 설정 추가
```java
@Configuration
@EnableWebSecurity
public class SecurityConfig extends WebSecurityConfigurerAdapter {

    @Override
    protected void configure(HttpSecurity http) throws Exception {
        http.authorizeRequests()
                .mvcMatchers("/", "/info").permitAll()
                .mvcMatchers("/admin").hasRole("ADMIN")
                .anyRequest().authenticated();

        http.formLogin();
        http.httpBasic();
    }
}
```

해결한 문제
- 요청 URL별 인증 설정

남아있는 문제
- 여전히 계정은 하나 뿐. 
- ADMIN 계정도 없음.
- 비밀번호도 여전히 로그에 남는다.

## 스프링 시큐리티 커스터마이징: 인메모리 유저 추가

지금까지 스프링 부트가 만들어 주던 유저 정보는?
- UserDetailsServiceAutoConfiguration
- SecurityProperties

SecurityProperties를 사용해서 기본 유저 정보 변경할 수 있긴 하지만...

SecurityConfig에 다음 설정 추가
```java
@Override
protected void configure(AuthenticationManagerBuilder auth) throws Exception {
    auth.inMemoryAuthentication()
            .withUser("keesun").password("{noop}123").roles("USER").and()
            .withUser("admin").password("{noop}!@#").roles("ADMIN");
}

@Bean
@Override
public AuthenticationManager authenticationManagerBean() throws Exception {
    return super.authenticationManagerBean();
}
```
- 인메모리 사용자 추가
- 로컬 `AuthenticationManager`를 빈으로 노출

해결한 문제
- 계정 여러개 사용할 수 있음.
- ADMIN 계정도 있음

남아있는 문제
- 비밀번호가 코드에 보인다. 
- 데이터베이스에 들어있는 유저 정보를 사용하고 싶다.

## 스프링 시큐리티 커스터마이징: JPA 연동

JPA와 H2 의존성 추가
```
<dependency>
	<groupId>org.springframework.boot</groupId>
	<artifactId>spring-boot-starter-data-jpa</artifactId>
</dependency>
<dependency>
	<groupId>com.h2database</groupId>
	<artifactId>h2</artifactId>
	<scope>runtime</scope>
</dependency>
```

Account 클래스
```java
@Entity
public class Account {

    @Id @GeneratedValue
    private Integer id;

    @Column(unique = true)
    private String username;

    private String password;

    private String role;
```

AccountRepository 인터페이스
```java
public interface AccountRepository extends JpaRepository<Account, Integer> {
    Account findByUsername(String username);
}
```

AccountSerivce 클래스 implements UserDetailsService
```java
@Service
public class AccountService implements UserDetailsService {

    @Autowired
    AccountRepository accountRepository;

    @Override
    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
        Account account = accountRepository.findByUsername(username);
        if (account == null) {
            throw new UsernameNotFoundException(username);
        }

        return User.builder()
                .username(account.getUsername())
                .password(account.getPassword())
                .roles(account.getRole())
                .build();
    }
}
```

해결한 문제
- 패스워드가 코드에 보이지 않는다.
- DB에 들어있는 계정 정보를 사용할 수 있다.

새로운 문제
- “{noop}”을 없앨 수는 없을까?
- 테스트는 매번 이렇게 해야 하는건가?

## 스프링 시큐리티 커스터마이징: PasswordEncoder

비밀번호는 반드시 인코딩해서 저장해야 합니다. 단방향 암호화 알고리듬으로.
- 스프링 시큐리티가 제공하는 PasswordEndoer는 특정한 포맷으로 동작함.
- {id}encodedPassword
- 다양한 해싱 전략의 패스워드를 지원할 수 있다는 장점이 있습니다.

기본 전략인 bcrypt로 암호화 해서 저장하며 비교할 때는 {id}를 확인해서 다양한 인코딩을 지원합니다.
```java
@Bean
public PasswordEncoder passwordEncoder() {
	return PasswordEncoderFactories.createDelegatingPasswordEncoder();
}
```

해결한 문제
- “{noop}”을 없앴다. 비밀번호가 좀 더 안전해졌다.

남아있는 문제
- 테스트는 매번 이렇게 해야 하는건가?

## 스프링 시큐리티 테스트

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#test-mockmvc

Spring-Security-Test 의존성 추가
```
<dependency>
	<groupId>org.springframework.security</groupId>
	<artifactId>spring-security-test</artifactId>
	<scope>test</scope>
</dependency>
```
- 테스트에서 사용할 기능을 제공하기 때문에 Test 스콥이 적절합니다.

RequestPostProcessor를 사용해서 테스트 하는 방법
- `with(user(“user”))`
- `with(anonymous())`
- `with(user(“user”).password(“123”).roles(“USER”, “ADMIN”))`
- 자주 사용하는 user  객체는 리팩토리으로 빼내서 재사용 가능.

애노테이션을 사용하는 방법
- `@WithMockUser`
- `@WithMockUser(roles=”ADMIN”)`
- 커스텀 애노테이션을 만들어 재사용 가능.

폼 로그인 / 로그아웃 테스트
- `perform(formLogin())`
- `perform(formLogin().user("admin").password("pass"))`
- `perform(logout())`

응답 유형 확인
- `authenticated()`
- `unauthenticated()`

해결한 문제
- 스프링 시큐리티 테스트를 작성할 수 있다.

