### PR TITLE
스프링 시큐리티: 아키텍처

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@
 ## 학습 목차
 
 #### 1. [스프링 시큐리티: 폼 인증](https://github.com/Junhan0037/spring-security/pull/1)
+#### 2. [스프링 시큐리티: 아키텍처](https://github.com/Junhan0037/spring-security/pull/2)
 
 해당 repo는 [스프링 시큐리티 - 백기선](https://www.inflearn.com/course/%EB%B0%B1%EA%B8%B0%EC%84%A0-%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0) 해당 강의를 듣고 정리한 REPO 입니다.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 
 ## 학습 목차
 
+#### 1. [스프링 시큐리티: 폼 인증](https://github.com/Junhan0037/spring-security/pull/1)
 
 해당 repo는 [스프링 시큐리티 - 백기선](https://www.inflearn.com/course/%EB%B0%B1%EA%B8%B0%EC%84%A0-%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0) 해당 강의를 듣고 정리한 REPO 입니다.

--- a/src/main/java/com/springsecurity/account/AccountContext.java
+++ b/src/main/java/com/springsecurity/account/AccountContext.java
@@ -1,0 +1,15 @@
+package com.springsecurity.account;
+
+public class AccountContext {
+
+    private static final ThreadLocal<Account> ACCOUNT_THREAD_LOCAL = new ThreadLocal<>();
+
+    public static Account getAccount() {
+        return ACCOUNT_THREAD_LOCAL.get();
+    }
+
+    public static void setAccount(Account account) {
+        ACCOUNT_THREAD_LOCAL.set(account);
+    }
+
+}

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -1,14 +1,26 @@
 package com.springsecurity.config;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.access.expression.SecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    public SecurityExpressionHandler expressionHandler() {
+        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
+        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");
+
+        DefaultWebSecurityExpressionHandler handler = new DefaultWebSecurityExpressionHandler();
+        handler.setRoleHierarchy(roleHierarchy);
+
+        return handler;
+    }
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -16,10 +28,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .mvcMatchers("/", "/info", "/account/**").permitAll()
                 .mvcMatchers("/admin").hasRole("ADMIN")
                 .anyRequest().authenticated()
-                .and()
-                    .formLogin()
-                .and()
-                    .httpBasic();
+                .expressionHandler(expressionHandler());
+        http.formLogin();
+        http.httpBasic();
     }
 
     /*

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -1,5 +1,6 @@
 package com.springsecurity.form;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,7 +8,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import java.security.Principal;
 
 @Controller
+@RequiredArgsConstructor
 public class SampleController {
+
+    private final SampleService sampleService;
 
     @GetMapping("/")
     public String index(Model model) {
@@ -28,7 +32,7 @@ public class SampleController {
         } else {
             model.addAttribute("message", "Hello " + principal.getName());
         }
-
+        sampleService.dashboard();
         return "dashboard";
     }
 

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -1,5 +1,8 @@
 package com.springsecurity.form;
 
+import com.springsecurity.account.Account;
+import com.springsecurity.account.AccountContext;
+import com.springsecurity.account.AccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -12,6 +15,7 @@ import java.security.Principal;
 public class SampleController {
 
     private final SampleService sampleService;
+    private final AccountRepository accountRepository;
 
     @GetMapping("/")
     public String index(Model model) {
@@ -32,6 +36,10 @@ public class SampleController {
         } else {
             model.addAttribute("message", "Hello " + principal.getName());
         }
+
+        Account account = accountRepository.findByUsername(principal.getName());
+        AccountContext.setAccount(account);
+
         sampleService.dashboard();
         return "dashboard";
     }

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -36,10 +36,6 @@ public class SampleController {
         } else {
             model.addAttribute("message", "Hello " + principal.getName());
         }
-
-        Account account = accountRepository.findByUsername(principal.getName());
-        AccountContext.setAccount(account);
-
         sampleService.dashboard();
         return "dashboard";
     }

--- a/src/main/java/com/springsecurity/form/SampleService.java
+++ b/src/main/java/com/springsecurity/form/SampleService.java
@@ -1,13 +1,9 @@
 package com.springsecurity.form;
 
-import com.springsecurity.account.Account;
-import com.springsecurity.account.AccountContext;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
-
-import java.util.Collection;
 
 @Service
 public class SampleService {
@@ -21,9 +17,16 @@ public class SampleService {
         boolean authenticated = authentication.isAuthenticated();
          */
 
+        /* ThreadLocal
         Account account = AccountContext.getAccount();
         System.out.println("=======================");
         System.out.println(account.getUsername());
+         */
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        System.out.println("=======================");
+        System.out.println(userDetails.getUsername());
     }
 
 }

--- a/src/main/java/com/springsecurity/form/SampleService.java
+++ b/src/main/java/com/springsecurity/form/SampleService.java
@@ -1,5 +1,7 @@
 package com.springsecurity.form;
 
+import com.springsecurity.account.Account;
+import com.springsecurity.account.AccountContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -11,11 +13,17 @@ import java.util.Collection;
 public class SampleService {
 
     public void dashboard() {
+        /*
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         Object principal = authentication.getPrincipal();
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
         Object credentials = authentication.getCredentials();
         boolean authenticated = authentication.isAuthenticated();
+         */
+
+        Account account = AccountContext.getAccount();
+        System.out.println("=======================");
+        System.out.println(account.getUsername());
     }
 
 }

--- a/src/main/java/com/springsecurity/form/SampleService.java
+++ b/src/main/java/com/springsecurity/form/SampleService.java
@@ -1,0 +1,21 @@
+package com.springsecurity.form;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@Service
+public class SampleService {
+
+    public void dashboard() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication.getPrincipal();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Object credentials = authentication.getCredentials();
+        boolean authenticated = authentication.isAuthenticated();
+    }
+
+}


### PR DESCRIPTION
## SecurityContextHolder와 Authentication

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#core-components

`SecurityContextHolder`
- SecurityContext 제공, 기본적으로 ThreadLocal을 사용한다.

`SecurityContext`
- Authentication 제공.

![image](https://user-images.githubusercontent.com/63000763/102975073-da721600-4542-11eb-83b6-913ce08f87bb.png)

`Authentication`
- Principal과 GrantAuthority 제공.

`Principal`
- “누구"에 해당하는 정보. 
- UserDetailsService에서 리턴한 그 객체.
- 객체는 UserDetails 타입.

`GrantAuthority` 
- “ROLE_USER”, “ROLE_ADMIN”등 Principal이 가지고 있는 “권한”을 나타낸다.
- 인증 이후, 인가 및 권한 확인할 때 이 정보를 참조한다.

`UserDetails`
- 애플리케이션이 가지고 있는 유저 정보와 스프링 시큐리티가 사용하는 Authentication 객체 사이의 어댑터.

`UserDetailsService`
- 유저 정보를 UserDetails 타입으로 가져오는 DAO (Data Access Object) 인터페이스.
- 구현은 마음대로! (여기서는 스프링 데이터 JPA를 사용했습니다.)

## AuthenticationManager와 Authentication

스프링 시큐리티에서 인증(Authentication)은 `AuthenticationManager`가 한다.

```java
Authentication authenticate(Authentication authentication) throws AuthenticationException;
```
- 인자로 받은 Authentication이 유효한 인증인지 확인하고 Authentication 객체를 리턴한다.
- 인증을 확인하는 과정에서 비활성 계정, 잘못된 비번, 잠긴 계정 등의 에러를 던질 수 있다

### 인자로 받은 Authentication
- 사용자가 입력한 인증에 필요한 정보(username, password)로 만든 객체. (폼 인증인 경우)
- Authentication
    - Principal: “keesun”
    - Credentials: “123”

### 유효한 인증인지 확인
- 사용자가 입력한 password가 UserDetailsService를 통해 읽어온 UserDetails 객체에 들어있는 password와 일치하는지 확인
- 해당 사용자 계정이 잠겨 있진 않은지, 비활성 계정은 아닌지 등 확인

### Authentication 객체를 리턴
- `Authentication`
    - `Principal`: UserDetailsService에서 리턴한 그 객체 (User)
    - `Credentials`
    - `GrantedAuthorities`

## ThreadLocal

Java.lang 패키지에서 제공하는 쓰레드 범위 변수. 즉, 쓰레드 수준의 데이터 저장소.
- 같은 쓰레드 내에서만 공유.
- 따라서 같은 쓰레드라면 해당 데이터를 메소드 매개변수로 넘겨줄 필요 없음.
- SecurityContextHolder의 기본 전략.
``` java
public class AccountContext {

    private static final ThreadLocal<Account> ACCOUNT_THREAD_LOCAL
            = new ThreadLocal<>();

    public static void setAccount(Account account) {
        ACCOUNT_THREAD_LOCAL.set(account);
    }

    public static Account getAccount() {
        return ACCOUNT_THREAD_LOCAL.get();
    }

}
```

## Authencation과 SecurityContextHodler

AuthenticationManager가 인증을 마친 뒤 리턴 받은 Authentication 객체의 행방은?

`UsernamePasswordAuthenticationFilter`
- 폼 인증을 처리하는 시큐리티 필터
- 인증된 Authentication 객체를 SecurityContextHolder에 넣어주는 필터
- SecurityContextHolder.getContext().setAuthentication(authentication)

`SecurityContextPersisenceFilter`
- SecurityContext를 HTTP session에 캐시(기본 전략)하여 여러 요청에서 Authentication을 공유할 수 있 공유하는 필터.
- SecurityContextRepository를 교체하여 세션을 HTTP session이 아닌 다른 곳에 저장하는 것도 가능하다.

## 스프링 시큐리티 Filter와 FilterChainProxy

스프링 시큐리티가 제공하는 필터들
- WebAsyncManagerIntergrationFilter
- **SecurityContextPersistenceFilter**
- HeaderWriterFilter
- CsrfFilter
- LogoutFilter
- **UsernamePasswordAuthenticationFilter**
- DefaultLoginPageGeneratingFilter
- DefaultLogoutPageGeneratingFilter
- BasicAuthenticationFilter
- RequestCacheAwareFtiler
- SecurityContextHolderAwareReqeustFilter
- AnonymouseAuthenticationFilter
- SessionManagementFilter
- ExeptionTranslationFilter
- FilterSecurityInterceptor

이 모든 필터는 `FilterChainProxy`가 호출한다.
![image](https://user-images.githubusercontent.com/63000763/102975600-ae0ac980-4543-11eb-8ada-7543adfd96e4.png)

## DelegatingFilterProxy와 FilterChainProxy

`DelegatingFilterProxy`
- 일반적인 서블릿 필터.
- 서블릿 필터 처리를 스프링에 들어있는 빈으로 위임하고 싶을 때 사용하는 서블릿 필터.
- 타겟 빈 이름을 설정한다.
- 스프링 부트 없이 스프링 시큐리티 설정할 때는 `AbstractSecurityWebApplicationInitializer`를 사용해서 등록.
- 스프링 부트를 사용할 때는 자동으로 등록 된다. (`SecurityFilterAutoConfiguration`)

`FilterChainProxy`
- 보통 “springSecurityFilterChain” 이라는 이름의 빈으로 등록된다.
![image](https://user-images.githubusercontent.com/63000763/102975701-ce3a8880-4543-11eb-8f00-9601635b78be.png)

## AccessDecisionManager

Access Control 결정을 내리는 인터페이스로, 구현체 3가지를 기본으로 제공한다.
- **AffirmativeBased**: 여러 Voter중에 한명이라도 허용하면 허용. 기본 전략.
- ConsensusBased: 다수결
- UnanimousBased: 만장일치

`AccessDecisionVoter`
- 해당 Authentication이 특정한 Object에 접근할 때 필요한 ConfigAttributes를 만족하는지 확인한다.
- **WebExpressionVoter**: 웹 시큐리티에서 사용하는 기본 구현체, ROLE_Xxxx가 매치하는지 확인.
- RoleHierarchyVoter: 계층형 ROLE 지원. ADMIN > MANAGER > USER
...

### AccessDecisionManager 또는 Voter를 커스터마이징 하는 방법

계층형 ROLE 설정
```java
@Configuration
@EnableWebSecurity
public class SecurityConfig extends WebSecurityConfigurerAdapter {

    public SecurityExpressionHandler expressionHandler() {
        RoleHierarchyImpl roleHierarchy = new RoleHierarchyImpl();
        roleHierarchy.setHierarchy("ROLE_ADMIN > ROLE_USER");

        DefaultWebSecurityExpressionHandler handler = new DefaultWebSecurityExpressionHandler();
        handler.setRoleHierarchy(roleHierarchy);

        return handler;
    }

    @Override
    protected void configure(HttpSecurity http) throws Exception {
        http.authorizeRequests()
                .mvcMatchers("/", "/info", "/account/**").permitAll()
                .mvcMatchers("/admin").hasRole("ADMIN")
                .mvcMatchers("/user").hasRole("USER")
                .anyRequest().authenticated()
                .expressionHandler(expressionHandler());
        http.formLogin();
        http.httpBasic();
    }

}
```

## FilterSecurityInterceptor

AccessDecisionManager를 사용하여 Access Control 또는 예외 처리 하는 필터.
대부분의 경우 FilterChainProxy에 제일 마지막 필터로 들어있다.
![image](https://user-images.githubusercontent.com/63000763/102975848-0a6de900-4544-11eb-9320-b9e5f427804b.png)

## ExceptionTranslationFilter

필터 체인에서 발생하는 `AccessDeniedException`과 `AuthenticationException`을 처리하는 필터

`AuthenticationException` 발생 시
- AuthenticationEntryPoint 실행
- `AbstractSecurityInterceptor` 하위 클래스(예, `FilterSecurityInterceptor`)에서 발생하는 예외만 처리.
- 그렇다면 `UsernamePasswordAuthenticationFilter`에서 발생한 인증 에러는?

`AccessDeniedException` 발생 시
- 익명 사용자라면 `AuthenticationEntryPoint` 실행
- 익명 사용자가 아니면 `AccessDeniedHandler`에게 위임

## 스프링 시큐리티 아키텍처 정리

![image](https://user-images.githubusercontent.com/63000763/102975961-32f5e300-4544-11eb-92d3-570d9614c22f.png)

참고
- https://spring.io/guides/topicals/spring-security-architecture
- https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#overall-architecture
