### PR TITLE
웹 애플리케이션 시큐리티

### DIFF
--- a/src/main/java/com/springsecurity/SpringSecurityApplication.java
+++ b/src/main/java/com/springsecurity/SpringSecurityApplication.java
@@ -3,10 +3,12 @@ package com.springsecurity;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @SpringBootApplication
+@EnableAsync
 public class SpringSecurityApplication {
 
     @Bean

--- a/src/main/java/com/springsecurity/account/AccountController.java
+++ b/src/main/java/com/springsecurity/account/AccountController.java
@@ -1,19 +1,31 @@
 package com.springsecurity.account;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseBody;
 
-@RestController
+@Controller
 @RequiredArgsConstructor
 public class AccountController {
 
     private final AccountService accountService;
 
+    @ResponseBody
     @GetMapping("/account/{role}/{username}/{password}") // 임시 회원가입 컨트롤러
     public Account createAccount(@ModelAttribute Account account) {
         return accountService.createNew(account);
+    }
+
+    @GetMapping("/login")
+    public String loginForm() {
+        return "login";
+    }
+
+    @GetMapping("/logout")
+    public String logoutForm() {
+        return "logout";
     }
 
 }

--- a/src/main/java/com/springsecurity/account/SignUpController.java
+++ b/src/main/java/com/springsecurity/account/SignUpController.java
@@ -1,0 +1,30 @@
+package com.springsecurity.account;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/signup")
+public class SignUpController {
+
+    @Autowired AccountService accountService;
+
+    @GetMapping
+    public String signUpForm(Model model) {
+        model.addAttribute("account", new Account());
+        return "signup";
+    }
+
+    @PostMapping
+    public String processSignUp(@ModelAttribute Account account) {
+        account.setRole("USER");
+        accountService.createNew(account);
+        return "redirect:/";
+    }
+
+}

--- a/src/main/java/com/springsecurity/common/LoggingFilter.java
+++ b/src/main/java/com/springsecurity/common/LoggingFilter.java
@@ -1,0 +1,30 @@
+package com.springsecurity.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StopWatch;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class LoggingFilter extends GenericFilterBean {
+
+    private Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start(((HttpServletRequest)servletRequest).getRequestURI());
+
+        filterChain.doFilter(servletRequest, servletResponse);
+
+        stopWatch.stop();
+        logger.info(stopWatch.prettyPrint());
+    }
+
+}

--- a/src/main/java/com/springsecurity/common/SecurityLogger.java
+++ b/src/main/java/com/springsecurity/common/SecurityLogger.java
@@ -1,0 +1,15 @@
+package com.springsecurity.common;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class SecurityLogger {
+
+    public static void log(String message) {
+        System.out.println(message);
+        Thread thread = Thread.currentThread();
+        System.out.println("Thread : " + thread.getName());
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println("Principal : " + principal);
+    }
+
+}

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -1,9 +1,11 @@
 package com.springsecurity.config;
 
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
@@ -23,10 +25,17 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+        web.ignoring().requestMatchers(PathRequest.toH2Console());
+    }
+
+    @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
                 .mvcMatchers("/", "/info", "/account/**").permitAll()
                 .mvcMatchers("/admin").hasRole("ADMIN")
+//                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated()
                 .expressionHandler(expressionHandler());
         http.formLogin();

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 
 @Configuration
@@ -40,6 +41,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .expressionHandler(expressionHandler());
         http.formLogin();
         http.httpBasic();
+
+        SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL); // 하위 스레드에 SecurityContextHolder 공유
     }
 
     /*

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -39,8 +39,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 //                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated()
                 .expressionHandler(expressionHandler());
-        http.formLogin();
+        http.formLogin()
+                .loginPage("/login").permitAll();
         http.httpBasic();
+
+        http.logout().logoutSuccessUrl("/");
 
         SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL); // 하위 스레드에 SecurityContextHolder 공유
     }

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.springsecurity.config;
 
+import com.springsecurity.common.LoggingFilter;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
+import org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -33,6 +35,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        http.addFilterBefore(new LoggingFilter(), WebAsyncManagerIntegrationFilter.class);
+
         http.authorizeRequests()
                 .mvcMatchers("/", "/info", "/account/**", "/signup").permitAll()
                 .mvcMatchers("/admin").hasRole("ADMIN")

--- a/src/main/java/com/springsecurity/config/SecurityConfig.java
+++ b/src/main/java/com/springsecurity/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests()
-                .mvcMatchers("/", "/info", "/account/**").permitAll()
+                .mvcMatchers("/", "/info", "/account/**", "/signup").permitAll()
                 .mvcMatchers("/admin").hasRole("ADMIN")
 //                .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                 .anyRequest().authenticated()

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -3,12 +3,16 @@ package com.springsecurity.form;
 import com.springsecurity.account.Account;
 import com.springsecurity.account.AccountContext;
 import com.springsecurity.account.AccountRepository;
+import com.springsecurity.common.SecurityLogger;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.security.Principal;
+import java.util.concurrent.Callable;
 
 @Controller
 @RequiredArgsConstructor
@@ -44,6 +48,18 @@ public class SampleController {
     public String admin(Model model, Principal principal) {
         model.addAttribute("message", "Hello Admin, " + principal.getName());
         return "admin";
+    }
+
+    @GetMapping("/async-handler")
+    @ResponseBody
+    public Callable<String> asyncHandler() {
+        SecurityLogger.log("MVC");
+
+        return () -> {
+            SecurityLogger.log("Callable"); // Thread가 달라도, 동일한 Principal를 참조한다.
+            return "Async Handler";
+        };
+
     }
 
 }

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -1,11 +1,8 @@
 package com.springsecurity.form;
 
-import com.springsecurity.account.Account;
-import com.springsecurity.account.AccountContext;
 import com.springsecurity.account.AccountRepository;
 import com.springsecurity.common.SecurityLogger;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/springsecurity/form/SampleController.java
+++ b/src/main/java/com/springsecurity/form/SampleController.java
@@ -59,7 +59,15 @@ public class SampleController {
             SecurityLogger.log("Callable"); // Thread가 달라도, 동일한 Principal를 참조한다.
             return "Async Handler";
         };
+    }
 
+    @GetMapping("/async-service")
+    @ResponseBody
+    public String asyncService() {
+        SecurityLogger.log("MVC, before async service");
+        sampleService.asyncService();
+        SecurityLogger.log("MVC, after async service");
+        return "Async Service";
     }
 
 }

--- a/src/main/java/com/springsecurity/form/SampleService.java
+++ b/src/main/java/com/springsecurity/form/SampleService.java
@@ -1,5 +1,7 @@
 package com.springsecurity.form;
 
+import com.springsecurity.common.SecurityLogger;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -27,6 +29,12 @@ public class SampleService {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         System.out.println("=======================");
         System.out.println(userDetails.getUsername());
+    }
+
+    @Async
+    public void asyncService() {
+        SecurityLogger.log("Async Service");
+        System.out.println("Async service is called.");
     }
 
 }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <div th:if="${param.error}">
+        Invalid username or password.
+    </div>
+    <form action="/login" method="post" th:action="@{/login}">
+        <p>Username : <input type="text" name="username"></p>
+        <p>Username : <input type="password" name="password"></p>
+        <p><input type="submit" value="Login"></p>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/logout.html
+++ b/src/main/resources/templates/logout.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>Logout</title>
+</head>
+<body>
+<h1>Logout</h1>
+<form action="/logout" method="post" th:action="@{/logout}">
+    <p><input type="submit" value="Logout"></p>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th=”http://www.thymeleaf.org”>
+<head>
+    <meta charset="UTF-8">
+    <title>SignUp</title>
+</head>
+<body>
+    <form action="/signup" th:action="@{/signup}" th:object="${account}" method="post">
+        <p>Username: <input type="text" th:field="*{username}" /></p>
+        <p>Password: <input type="text" th:field="*{password}" /></p>
+        <p><input type="submit" value="SignUp" /></p>
+    </form>
+</body>
+</html>

--- a/src/test/java/com/springsecurity/account/SignUpControllerTest.java
+++ b/src/test/java/com/springsecurity/account/SignUpControllerTest.java
@@ -1,0 +1,42 @@
+package com.springsecurity.account;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class SignUpControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    public void signUpForm() throws Exception {
+        mockMvc.perform(get("/signup"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("_csrf")));
+    }
+
+    @Test
+    public void processSignUp() throws Exception {
+        mockMvc.perform(post("/signup")
+                        .param("username", "junhan")
+                        .param("password", "123")
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().is3xxRedirection());
+    }
+
+}


### PR DESCRIPTION
## 스프링 시큐리티 ignoring()

WebSecurity의 ignoring()을 사용해서 시큐리티 필터 적용을 제외할 요청을 설정할 수 있다.
```java
@Override
public void configure(WebSecurity web) throws Exception {
    web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
}
```
- 스프링 부트가 제공하는 PathRequest를 사용해서 정적 자원 요청을 스프링 시큐리티 필터를 적용하지 않도록 설정

```java
http.authorizeRequests()
    .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
```
이런 설정으로도 같은 결과를 볼 수는 있지만 스프링 시큐리티 필터가 적용된다는 차이가 있다.
- 동적 리소스는 http.authorizeRequests()에서 처리하는 것을 권장합니다.
- 정적 리소스는 WebSecurity.ignore()를 권장하며 예외적인 정적 자원 (인증이 필요한 정적자원이 있는 경우)는 http.authorizeRequests()를 사용할 수 있습니다.


## Async 웹 MVC를 지원하는 필터: WebAsyncManagerIntegrationFilter

스프링 MVC의 Async 기능(핸들러에서 Callable을 리턴할 수 있는 기능)을 사용할 때에도 SecurityContext를 공유하도록 도와주는 필터.
- `PreProcess`: SecurityContext를 설정한다.
- `Callable`: 비록 다른 쓰레드지만 그 안에서는 동일한 SecurityContext를 참조할 수 있다.
- `PostProcess`: SecurityContext를 정리(clean up)한다.

## 스프링 시큐리티와 @Async

### `@Async`를 사용한 서비스를 호출하는 경우
- 쓰레드가 다르기 때문에 SecurityContext를 공유받지 못한다.
```java
SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
```
- SecurityContext를 자식 쓰레드에도 공유하는 전략.
- `@Async`를 처리하는 쓰레드에서도 SecurityContext를 공유받을 수 있다.

참고
- https://docs.oracle.com/javase/7/docs/api/java/lang/InheritableThreadLocal.html

## SecurityContext 영속화 필터: SecurityContextPersistenceFilter

SecurityContextRepository를 사용해서 기존의 SecurityContext를 읽어오거나 초기화 한다.
- 기본으로 사용하는 전략은 HTTP Session을 사용한다.
- Spring-Session과 연동하여 세션 클러스터를 구현할 수 있다.
![image](https://user-images.githubusercontent.com/63000763/103195675-15e75880-4926-11eb-8896-5c509e3cc2ab.png)

## 시큐리티 관련 헤더 추가하는 필터: HeaderWriterFilter

응답 헤더에 시큐리티 관련 헤더를 추가해주는 필터
- XContentTypeOptionsHeaderWriter: 마임 타입 스니핑 방어.
- XXssProtectionHeaderWriter: 브라우저에 내장된 XSS 필터 적용.
- CacheControlHeadersWriter: 캐시 히스토리 취약점 방어.
- HstsHeaderWriter: HTTPS로만 소통하도록 강제.
- XFrameOptionsHeaderWriter: clickjacking 방어.

Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Content-Language: en-US
Content-Type: text/html;charset=UTF-8
Date: Sun, 04 Aug 2019 16:25:10 GMT
Expires: 0
Pragma: no-cache
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block
![image](https://user-images.githubusercontent.com/63000763/103195729-2e577300-4926-11eb-8511-6b53ac2773e0.png)

참고
- X-Content-Type-Options:
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
- Cache-Control:
    - https://www.owasp.org/index.php/Testing_for_Browser_cache_weakness_(OTG-AUTHN-006)
- X-XSS-Protection
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
    - https://github.com/naver/lucy-xss-filter
- HSTS
    - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
- X-Frame-Options
    - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options
- https://cyberx.tistory.com/171

## CSRF 어택 방지 필터: CsrfFilter

### CSRF 어택 방지 필터
- 인증된 유저의 계정을 사용해 악의적인 변경 요청을 만들어 보내는 기법.
- https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)
- https://namu.wiki/w/CSRF
- CORS를 사용할 때 특히 주의 해야 함.
    - 타 도메인에서 보내오는 요청을 허용하기 때문에...
    - https://en.wikipedia.org/wiki/Cross-origin_resource_sharing
![image](https://user-images.githubusercontent.com/63000763/103195846-68287980-4926-11eb-880b-27dfb5e45fb8.png)

### 의도한 사용자만 리소스를 변경할 수 있도록 허용하는 필터
- CSRF 토큰을 사용하여 방지.
![image](https://user-images.githubusercontent.com/63000763/103195863-71b1e180-4926-11eb-8b4a-4ba5f3cb089d.png)

## CSRF 토큰 사용 예제

JSP에서 스프링 MVC가 제공하는 <form:form> 태그 또는 타임리프 2.1+ 버전을 사용할 때 폼에 CRSF 히든 필드가 기본으로 생성 됨.

Signup.html
```html
<!DOCTYPE html>
<html lang="en" xmlns:th="http://www.thymeleaf.org">
<head>
    <meta charset="UTF-8">
    <title>SignUp</title>
</head>
<body>
    <h1>Sign Up</h1>
    <form action="/signup" th:action="@{/signup}" th:object="${account}" method="post">
        <p>Username: <input type="text" th:field="*{username}" /></p>
        <p>Password: <input type="text" th:field="*{password}" /></p>
        <p><input type="submit" value="Submit" /></p>
    </form>
</body>
</html>
```

SignUpController.class
```java
@Controller
public class SignUpController {

    @Autowired
    AccountService accountService;

    @GetMapping("/signup")
    public String signUpForm(Model model) {
        model.addAttribute("account", new Account());
        return "signup";
    }

    @PostMapping("/signup")
    public String processSignUp(@ModelAttribute Account account) {
        account.setRole("USER");
        accountService.createNew(account);
        return "redirect:/";
    }

}
```

SignUpControllerTest.class
```java
@RunWith(SpringRunner.class)
@SpringBootTest
@AutoConfigureMockMvc
public class SignUpControllerTest {

    @Autowired
    MockMvc mockMvc;

    @Test
    public void signUpForm() throws Exception {
        mockMvc.perform(get("/signup"))
                .andDo(print())
                .andExpect(content().string(containsString("_csrf")));
    }

    @Test
    public void procesSignUp() throws Exception {
        mockMvc.perform(post("/signup")
            .param("username", "keesun")
            .param("password", "123")
            .with(csrf()))
                .andExpect(status().is3xxRedirection());
    }
}
```

## 로그아웃 처리 필터: LogoutFilter

여러 LogoutHandler를 사용하여 로그아웃시 필요한 처리를 하며 이후에는 LogoutSuccessHandler를 사용하여 로그아웃 후처리를 한다.

### LogoutHandler
- CsrfLogoutHandler
- SecurityContextLogoutHandler

### LogoutSuccessHandler
- SimplUrlLogoutSuccessHandler

### 로그아웃 필터 설정
```java
http.logout()
        .logoutUrl("/logout")
        .logoutSuccessUrl("/")
        .logoutRequestMatcher()
        .invalidateHttpSession(true)
        .deleteCookies()
        .addLogoutHandler()
        .logoutSuccessHandler();
```

![image](https://user-images.githubusercontent.com/63000763/103196042-cd7c6a80-4926-11eb-9b2c-311d17782974.png)

## 폼 인증 처리 필터: UsernamePasswordAuthenticationFilter

폼 로그인을 처리하는 인증 필터
- 사용자가 폼에 입력한 username과 password로 Authentcation을 만들고 AuthenticationManager를 사용하여 인증을 시도한다.
- AuthenticationManager (ProviderManager)는 여러 AuthenticationProvider를 사용하여 인증을 시도하는데, 그 중에 DaoAuthenticationProvider는 UserDetailsServivce를 사용하여 UserDetails 정보를 가져와 사용자가 입력한 password와 비교한다.
![image](https://user-images.githubusercontent.com/63000763/103196103-e8e77580-4926-11eb-806b-90907dfd478a.png)

## DefaultLoginPageGeneratingFilter

### 기본 로그인 폼 페이지를 생성해주는 필터
- GET /login 요청을 처리하는 필터.

### 로그인 폼 커스터마이징
```java
 http.formLogin()
                .usernameParameter("my-username")
                .passwordParameter("my-password");
```
![image](https://user-images.githubusercontent.com/63000763/103196164-fef53600-4926-11eb-8d3b-f574f9f7baf4.png)

## 로그인/로그아웃 폼 커스터마이징

https://docs.spring.io/spring-security/site/docs/current/reference/html5/#jc-form

Signin.html
```html
<!DOCTYPE html>
<html lang="en" xmlns:th="http://www.thymeleaf.org">
<head>
    <meta charset="UTF-8">
    <title>SignIn</title>
</head>
<body>
    <h1>Sign In</h1>
    <div th:if="${param.error}">
        <div class="alert alert-danger">
            Invalid username or password.
        </div>
    </div>
    <form action="/signin" th:action="@{/signin}" method="post">
        <p>Username: <input type="text" name="username" /></p>
        <p>Password: <input type="password" name="password" /></p>
        <p><input type="submit" value="SignIn" /></p>
    </form>
</body>
</html>
```

Logout.html
```html
<!DOCTYPE html>
<html lang="en" xmlns:th="http://www.thymeleaf.org">
<head>
    <meta charset="UTF-8">
    <title>SignIn</title>
</head>
<body>
    <h1>Logout</h1>
    <form action="/logout" th:action="@{/logout}" method="post">
        <p><input type="submit" value="Logout" /></p>
    </form>
</body>
</html>
```

시큐리티 설정
```java
http.formLogin()
            .loginPage("/signin")
            .permitAll();
```

## Basic 인증 처리 필터: BasicAuthenticationFilter

### Basic 인증이란?
- https://tools.ietf.org/html/rfc7617
- 요청 헤더에 username와 password를 실어 보내면 브라우저 또는 서버가 그 값을 읽어서 인증하는 방식. 예) Authorization: Basic QWxhZGRpbjpPcGVuU2VzYW1l (keesun:123 을 BASE 64)
- 보통, 브라우저 기반 요청이 클라이언트의 요청을 처리할 때 자주 사용.
- 보안에 취약하기 때문에 반드시 HTTPS를 사용할 것을 권장.

## 요청 캐시 필터: RequestCacheAwareFilter

### 현재 요청과 관련 있는 캐시된 요청이 있는지 찾아서 적용하는 필터.
- 캐시된 요청이 없다면, 현재 요청 처리
- 캐시된 요청이 있다면, 해당 캐시된 요청 처리

## 시큐리티 관련 서블릿 스팩 구현 필터: SecurityContextHolderAwareRequestFilter

### 시큐리티 관련 서블릿 API를 구현해주는 필터
- HttpServletRequest#authenticate(HttpServletResponse)
- HttpServletRequest#login(String, String)
- HttpServletRequest#logout()
- AsyncContext#start(Runnable)
![image](https://user-images.githubusercontent.com/63000763/103196315-51365700-4927-11eb-939f-3844931203de.png)

## 익명 인증 필터: AnonymousAuthenticationFilter

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#anonymous

현재 SecurityContext에 Authentication이 null이면 “익명 Authentication”을 만들어 넣어주고, null이 아니면 아무일도 하지 않는다.

기본으로 만들어 사용할 “익명 Authentication” 객체를 설정할 수 있다.
```java
http.anonymous()
        .principal()
        .authorities()
        .key()
```

참고
- https://en.wikipedia.org/wiki/Null_object_pattern

## 세션 관리 필터: SessionManagementFilter

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#session-mgmt

### 세션 변조 방지 전략 설정: sessionFixation
- 세션 변조: https://www.owasp.org/index.php/Session_fixation
- none
- newSession
- migrateSession (서블릿 3.0- 컨테이너 사용시 기본값)
- changeSessionId (서브릿 3.1+ 컨테이너 사용시 기본값)
- https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#nsa-session-management-attributes

### 유효하지 않은 세션을 리다이렉트 시킬 URL 설정
- invalidSessionUrl

### 동시성 제어: maximumSessions
- 추가 로그인을 막을지 여부 설정 (기본값, false)
- https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#nsa-concurrency-control

### 세션 생성 전략: sessionCreationPolicy
- **IF_REQUIRED**
- NEVER
- STATELESS
- ALWAYS

## 인증/인가 예외 처리 필터: ExceptionTranslationFilter

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#exception-translation-filter

### 인증, 인가 에러 처리를 담당하는 필터
- AuthenticationEntryPoint
- AccessDeniedHandler

Access-denied.html
```html
<!DOCTYPE html>
<html lang="en" xmlns:th="http://www.thymeleaf.org">
<head>
    <meta charset="UTF-8">
    <title>Access Denied</title>
</head>
<body>
    <h1><span th:text="${name}">Name</span>, you can't access to the resource.</h1>
</body>
</html>
```

ExceptionHandler 설정
```java
http.exceptionHandling()
                .accessDeniedHandler((request, response, accessDeniedException) -> {
                    UserDetails principal = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
                    String username = principal.getUsername();
                    String servletPath = request.getServletPath();
                    System.out.println(username + " is denied to access to " + servletPath);
                    response.sendRedirect("/access-denied");
                });
```

## 인가 처리 필터: FilterSecurityInterceptor

https://docs.spring.io/spring-security/site/docs/5.1.5.RELEASE/reference/htmlsingle/#filter-security-interceptor

HTTP 리소스 시큐리티 처리를 담당하는 필터. AccessDecisionManager를 사용하여 인가를 처리한다.

HTTP 리로스 시큐리티 설정
```java
 http.authorizeRequests()
                .mvcMatchers("/", "/info", "/account/**", "/signup").permitAll()
                .mvcMatchers("/admin").hasAuthority("ROLE_ADMIN")
                .mvcMatchers("/user").hasRole("USER")
                .anyRequest().authenticated()
                .expressionHandler(expressionHandler());
```
![image](https://user-images.githubusercontent.com/63000763/103196722-0b2dc300-4928-11eb-9278-30d8235c690e.png)

## 토큰 기반 인증 필터 : RememberMeAuthenticationFilter

세션이 사라지거나 만료가 되더라도 쿠키 또는 DB를 사용하여 저장된 토큰 기반으로 인증을 지원하는 필터

RememberMe 설정
```java
http.rememberMe()
        .userDetailsService(accountService)
        .key("remember-me-sample");
```

## 커스텀 필터 추가하기

LoggingFilter.java
```java
public class LoggingFilter extends GenericFilterBean {

    private Logger logger = LoggerFactory.getLogger(this.getClass());

    @Override
    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
        StopWatch stopWatch = new StopWatch();
        stopWatch.start(((HttpServletRequest)request).getRequestURI());
        chain.doFilter(request, response);
        stopWatch.stop();
        logger.info(stopWatch.prettyPrint());
    }
}
```

커스텀 필터 추가 설정
```java
http.addFilterAfter(new LoggingFilter(), UsernamePasswordAuthenticationFilter.class);
```
